### PR TITLE
Fix interactives

### DIFF
--- a/src/components/LineChart.vue
+++ b/src/components/LineChart.vue
@@ -222,7 +222,7 @@
       </g>
       <g
         id="swe-annotations"
-        class="brush"
+        class="swe-cb"
       >
         <g class="annotation swe swe-cb swe-annotation-2011">
           <text

--- a/src/components/SNTLmap.vue
+++ b/src/components/SNTLmap.vue
@@ -2148,186 +2148,175 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-.leggy {
-  display: inline-block;
-}
-.figureCaption {
-  display: block;
-}
-.dot_peak {
+  .leggy {
+    display: inline-block;
+  }
+  .figureCaption {
+    display: block;
+  }
+  .dot_peak {
     width: 10px;
     height: 10px;
     border-radius: 50%;
     background: orchid;
     border: 0.35px solid orchid;
-        display: inline-block;  
-}
-.dot_melt {
+    display: inline-block;  
+  }
+  .dot_melt {
     width: 10px;
     height: 10px;
     border-radius: 50%;
     background: white;
     border: 1.5px solid orchid;
     display: inline-block;
-}
+  }
 
-.map-grid{
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  grid-template-areas: 
-    "legend legend legend legend legend ."
-    "ak ak ak ak ak ak"
-    "us us us us us us"
-    "peak peak peak wy21 wy21 wy21"
-    "melt melt melt wy21 wy21 wy21"
-  ;
-  overflow: hidden;
-}
-line, polyline, polygon, path, rect, circle {
-      fill: none;
-      stroke: grey;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-      stroke-miterlimit: 10.00;
-    }
-.explain {
-  font-style: italic;
-}
-.state {
-  stroke: white;
-  stroke-width: 2px;
-  opacity: .5;
-}
-.usa {
-  color: darkgrey;
-  fill:none;
-  stroke-width: 1px;
-}
-.map-container {
-    width: 100vw;
-}
-
-#legendContainer{
-  grid-area: legend;
-  margin-bottom: 0px;
-  margin-left: 30px;
-  z-index: 1;
-}
-
-#grid-left{
-  grid-area: ak;
-  width: 190vw;
-  margin-right: 2.5vw; 
-}
-#ak{
-  width: 110vw;// careful editing this, it's sizing the maps to be on the same scale
-}
-#grid-right{
-  grid-area: us;
-  width: 90vw;
-  margin-left: 70px;
-}
-#usa{
-  width: 160vw;// careful editing this, it's sizing the maps to be on the same scale
-}
-#peak-container{
-  grid-area: peak;
-}
-#melt-container{
-  grid-area: melt;
-}
-#wy21-container{
-  grid-area: wy21;
-}
-
-@media screen and (min-width: 1024px){
-  #melt-svg {
-  transform: translate(0, 0px);
-}
-#peak-svg {
-  transform: translate(0, -5px);
-}
   .map-grid{
-    
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
     grid-template-areas: 
-    ". legend legend us us us"
-    ". wy21 peak us us us"
-      ". wy21 peak us us us"
-      ". wy21 melt us us us"
-      ". wy21 melt us us us"
-      ". ak ak us us us"
-      ". ak ak us us us"
-      ". ak ak us us us"
-      ". ak ak us us us"
-      ". . . us us us"
+      "legend legend legend legend legend ."
+      "ak ak ak ak ak ak"
+      "us us us us us us"
+      "peak peak peak wy21 wy21 wy21"
+      "melt melt melt wy21 wy21 wy21"
     ;
+    overflow: hidden;
+  }
+  line, polyline, polygon, path, rect, circle {
+    fill: none;
+    stroke: grey;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-miterlimit: 10.00;
+  }
+  .explain {
+    font-style: italic;
+  }
+  .state {
+    stroke: white;
+    stroke-width: 2px;
+    opacity: .5;
+  }
+  .usa {
+    color: darkgrey;
+    fill:none;
+    stroke-width: 1px;
+  }
+  .map-container {
+    width: 100vw;
+  }
+  #legendContainer{
+    grid-area: legend;
+    margin-bottom: 0px;
+    margin-left: 30px;
+    z-index: 1;
   }
   #grid-left{
-    width: 30vw; // careful editing this, it's sizing the maps to the same scale
-    //margin-left: 10vw;
+    grid-area: ak;
+    width: 190vw;
+    margin-right: 2.5vw; 
   }
-  #legendContainer {
-    margin-top: 0px;
+  #ak{
+    width: 110vw;// careful editing this, it's sizing the maps to be on the same scale
   }
-  #ak {
-   width: 55vw;// 2x the width of the containerthis needs to match with #usa to keep scaling constant
-  }
-  #grid-right {
-    width: 70vw;// careful editing this, it's sizing the maps to the same scale
-    margin-right: 2.5vw;
-    margin-left: 0px;
+  #grid-right{
+    grid-area: us;
+    width: 90vw;
+    margin-left: 70px;
   }
   #usa{
-    width: 80vw; // 2x the width of the container, get cut off (intentionally). needs to be mirror with alaska
+    width: 160vw;// careful editing this, it's sizing the maps to be on the same scale
   }
- 
-}
+  #peak-container{
+    grid-area: peak;
+  }
+  #melt-container{
+    grid-area: melt;
+  }
+  #wy21-container{
+    grid-area: wy21;
+  }
 
-@media screen and (min-height: 900px){
-  #melt-svg {
-  transform: translate(0, 5px);
-}
-#peak-svg {
-  transform: translate(0, 0px);
-}
-  .map-grid{
-    
-    grid-template-areas: 
-    ". legend legend us us us"
-    ". wy21 peak us us us"
-      ". wy21 peak us us us"
-      ". wy21 melt us us us"
-      ". wy21 melt us us us"
-      "ak ak .  us us us"
-      "ak ak . us us us"
-      "ak ak . us us us"
-      "ak ak .us us us"
-      ". . . us us us";
+  @media screen and (min-width: 1024px){
+    #melt-svg {
+      transform: translate(0, 0px);
+    }
+    #peak-svg {
+      transform: translate(0, -5px);
+    }
+    .map-grid{
+      grid-template-areas: 
+        ". legend legend us us us"
+        ". wy21 peak us us us"
+        ". wy21 peak us us us"
+        ". wy21 melt us us us"
+        ". wy21 melt us us us"
+        ". ak ak us us us"
+        ". ak ak us us us"
+        ". ak ak us us us"
+        ". ak ak us us us"
+        ". . . us us us";
+    }
+    #grid-left{
+      width: 30vw; // careful editing this, it's sizing the maps to the same scale
+    }
+    #legendContainer {
+      margin-top: 0px;
+    }
+    #ak {
+      width: 55vw;// 2x the width of the containerthis needs to match with #usa to keep scaling constant
+    }
+    #grid-right {
+      width: 70vw;// careful editing this, it's sizing the maps to the same scale
+      margin-right: 2.5vw;
+      margin-left: 0px;
+    }
+    #usa{
+      width: 80vw; // 2x the width of the container, get cut off (intentionally). needs to be mirror with alaska
+    }
   }
-  #grid-left{
-    width: 30vw; // careful editing this, it's sizing the maps to the same scale
-    //margin-left: 10vw;
-  }
-  #legendContainer {
-    margin-top: 0px;
-    margin-left: 20px;
-  }
-  #ak {
-   width: 60vw;// 2x the width of the containerthis needs to match with #usa to keep scaling constant
-   margin-left: 30px;
-   padding-top: 50px;
-  }
-  #grid-right {
-    width: 70vw;// careful editing this, it's sizing the maps to the same scale
-    margin-right: 2.5vw;
-    margin-left: 0px;
-  }
-  #usa{
-    width: 100vw; // 2x the width of the container, get cut off (intentionally). needs to be mirror with alaska
-    margin-left: -25px;
-  }
- 
-}
 
-
+  @media screen and (min-height: 900px){
+    #melt-svg {
+      transform: translate(0, 5px);
+    }
+    #peak-svg {
+      transform: translate(0, 0px);
+    }
+    .map-grid{
+      grid-template-areas: 
+        ". legend legend us us us"
+        ". wy21 peak us us us"
+        ". wy21 peak us us us"
+        ". wy21 melt us us us"
+        ". wy21 melt us us us"
+        "ak ak . us us us"
+        "ak ak . us us us"
+        "ak ak . us us us"
+        "ak ak . us us us"
+        ". . . us us us";
+    }
+    #grid-left{
+      width: 30vw; // careful editing this, it's sizing the maps to the same scale
+    }
+    #legendContainer {
+      margin-top: 0px;
+      margin-left: 20px;
+    }
+    #ak {
+      width: 60vw;// 2x the width of the containerthis needs to match with #usa to keep scaling constant
+      margin-left: 30px;
+      padding-top: 50px;
+    }
+    #grid-right {
+      width: 70vw;// careful editing this, it's sizing the maps to the same scale
+      margin-right: 2.5vw;
+      margin-left: 0px;
+    }
+    #usa{
+      width: 100vw; // 2x the width of the container, get cut off (intentionally). needs to be mirror with alaska
+      margin-left: -25px;
+    }
+  }
 </style>

--- a/src/components/SNTLmap.vue
+++ b/src/components/SNTLmap.vue
@@ -2173,7 +2173,7 @@ export default {
 
   .map-grid{
     display: grid;
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(6, 16.6%);
     grid-template-areas: 
       "legend legend legend legend legend ."
       "ak ak ak ak ak ak"

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -546,15 +546,15 @@ export default {
           .attr("opacity", 0.5)
         }
       },
-      changePos(){
+      changePos(e){
         const self = this;
-          if(event.target.value == "peak"){
+          if(e.target.value == "peak"){
             self.toMagnitude()
           }
-          if(event.target.value == "time"){
+          if(e.target.value == "time"){
             self.toTiming();
           }
-           if(event.target.value == "el"){
+           if(e.target.value == "el"){
             self.toMagnitude()
             self.toElevation();
           }

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -355,12 +355,12 @@ export default {
               .tickFormat(function(d,i) { return self.tickDates[i] })
               .tickSizeOuter(0).tickSize(0))
 
-      // mmd axes
+        // mmd axes
         this.yAxis_mmd = g => g
           .attr("transform", `translate(${this.width-75},0)`)
           .call(this.d3.axisRight(y_mmd).tickSize(0).tickPadding(4).tickValues([0, 10, 20, 30]))
 
-          // mmd axes
+        // mmd axes
         this.yAxis_swe = g => g
           .attr("transform", `translate(${0},0)`)
           .call(this.d3.axisLeft(y_swe).tickSize(0).tickPadding(4).tickValues([0, 250, 500, 750, 1000]))
@@ -391,12 +391,13 @@ export default {
         this.line_swe = this.area_swe.lineY1()
           .defined(d => !isNaN(d));
 
-      // append g for each ridgeline/site_no
+        // append g for each ridgeline/site_no
         this.group = svg.append("g")
           .classed(ridge_class, true).classed("curve", true)
           .selectAll("g")
           .data(data_nest)
           .join("g")
+          .attr("class", d => "ridge_group " + d.key)
           .attr("transform", d => `translate(0,0)`)
 
         // draw MMD curves
@@ -460,46 +461,43 @@ export default {
       hover(data){
          const self = this;
 
-          self.d3.selectAll('g.curve path.mmd')
-            .attr("z-index", -1)
+          self.d3.selectAll('g.ridge_group')
+            .lower()
 
-          self.d3.selectAll('g.curve path.swe')
-            .attr("z-index", -1)
-
+          self.d3.selectAll('g.ridge_group.' + data.key)
+            .raise()
 
           self.d3.selectAll('g.curve path.mmd.' + data.key)
             .attr('stroke-width', "2px")
             .attr('stroke', "darkblue")
             .attr('stroke-opacity', .8)
-            .attr("z-index", 100);
 
           self.d3.selectAll('g.curve path.swe.' + data.key)
             .attr('stroke-width', "2px")
             .attr('stroke', "black")
             .attr('stroke-opacity', .8)
-            .attr("z-index", 100);
 
       },
       hoverOut(data){
          const self = this;
 
-          self.d3.selectAll('g.curve path.mmd.' + data.key)
+         self.d3.selectAll('g.ridge_group')
+            .lower()
+
+         self.d3.selectAll('g.curve path.mmd.' + data.key)
             .attr("stroke-width", "1px")
             .attr("stroke", this.color_mmd)
             .attr('stroke-opacity', .5)
-            .attr("z-index", -1);
 
         self.d3.selectAll('g.curve path.swe.' + data.key)
             .attr("stroke-width", "1px")
             .attr("stroke", this.color_swe)
             .attr('stroke-opacity', .5)
-            .attr("z-index", -1);
 
         self.d3.selectAll('g.curve path.mmd')
             .attr("stroke-width", "1px")
             .attr("stroke", this.color_mmd)
             .attr('stroke-opacity', .5)
-            .attr("z-index", -1)
 
         self.d3.selectAll('g.curve path.swe')
             .attr("stroke-width", "1px")

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -461,25 +461,19 @@ export default {
          const self = this;
 
           self.d3.selectAll('g.curve path.mmd')
-          .transition()
             .attr("z-index", -1)
 
-            self.d3.selectAll('g.curve path.swe')
-          .transition()
+          self.d3.selectAll('g.curve path.swe')
             .attr("z-index", -1)
 
 
           self.d3.selectAll('g.curve path.mmd.' + data.key)
-            .transition()
-            .duration(5)
             .attr('stroke-width', "2px")
             .attr('stroke', "darkblue")
             .attr('stroke-opacity', .8)
             .attr("z-index", 100);
 
-            self.d3.selectAll('g.curve path.swe.' + data.key)
-            .transition()
-            .duration(5)
+          self.d3.selectAll('g.curve path.swe.' + data.key)
             .attr('stroke-width', "2px")
             .attr('stroke', "black")
             .attr('stroke-opacity', .8)
@@ -490,33 +484,27 @@ export default {
          const self = this;
 
           self.d3.selectAll('g.curve path.mmd.' + data.key)
-            .transition()
-            .duration(5)
             .attr("stroke-width", "1px")
             .attr("stroke", this.color_mmd)
             .attr('stroke-opacity', .5)
             .attr("z-index", -1);
 
         self.d3.selectAll('g.curve path.swe.' + data.key)
-            .transition()
-            .duration(5)
             .attr("stroke-width", "1px")
             .attr("stroke", this.color_swe)
             .attr('stroke-opacity', .5)
             .attr("z-index", -1);
 
-             self.d3.selectAll('g.curve path.mmd')
-              .transition()
-              .attr("stroke-width", "1px")
-              .attr("stroke", this.color_mmd)
-              .attr('stroke-opacity', .5)
-              .attr("z-index", -1)
+        self.d3.selectAll('g.curve path.mmd')
+            .attr("stroke-width", "1px")
+            .attr("stroke", this.color_mmd)
+            .attr('stroke-opacity', .5)
+            .attr("z-index", -1)
 
-            self.d3.selectAll('g.curve path.swe')
-              .transition()
-              .attr("stroke-width", "1px")
-              .attr("stroke", this.color_swe)
-              .attr('stroke-opacity', .5)
+        self.d3.selectAll('g.curve path.swe')
+            .attr("stroke-width", "1px")
+            .attr("stroke", this.color_swe)
+            .attr('stroke-opacity', .5)
 
       },
       showSWE(){

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -293,7 +293,7 @@ export default {
         // nest data to iterate over in plot
         // sort of inverse of series - array of objects where objs = site containing key  for site_no, mmd and day vars
          data.mmd11 = [];
-          for (i = 1; i < n; i++) {
+          for (let i = 1; i < n; i++) {
               var key = this.site_elev[i];
               var mmd = data_2011.map(function(d){  return d[key]; });
               var swe = swe_2011.map(function(d){  return d[key]; });
@@ -302,7 +302,7 @@ export default {
           };
 
           data.mmd12 = [];
-          for (i = 1; i < n; i++) {
+          for (let i = 1; i < n; i++) {
               var key = this.site_elev[i];
               var mmd = data_2012.map(function(d){  return d[key]; });
               var swe = swe_2012.map(function(d){  return d[key]; });

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -310,7 +310,8 @@ export default {
               data.mmd12.push({key: key, mmd: mmd, day:day, swe:swe})
           };
 
-        data.days = data_2011.map(function(d) { return  d['site_water_day']}) // array of j days for good luck
+        // array of j days for good luck
+        data.days = data_2011.length > data_2012.length ? data_2011.map(function(d) { return  d['site_water_day']}) : data_2012.map(function(d) { return  d['site_water_day']})
 
         // set up g that holds ridgelines
         this.svgboth = this.d3.select('svg#mmd-line-both');
@@ -321,7 +322,8 @@ export default {
         var mid = x_long/2;
         var mar = mid*0.05
 
-        // set chart - separate for each year, using 2011 for max values to set the scales
+        // set chart - separate for each year, using 2011 for max values to set the scales, except
+        // x scale of days, which is set based on whichever year has more days (2012)
         //  first draw is MMD
         self.initRidges(this.svgboth, 'ridge_2011', data.mmd11, data.days, 0, x_long, 0, this.height/2-10);
         self.initRidges(this.svgboth, 'ridge_2012', data.mmd12, data.days, 0, x_long, this.height/2+10,  this.height);

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -74,7 +74,7 @@
             viewBox="-50 -50 600 500"
             aria-labelledby="page-title page-desc"
             width="100%"
-            height="auto"
+            height="100%"
           >
 
             <text

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -285,33 +285,33 @@ export default {
         var n = sites.length;
 
         // sort gages by elevation
-        this.site_elev = gage_sp.slice().sort((a,b) => this.d3.ascending(a.elev, b.elev)).map(function(d) { return d.site_no })
+        this.site_elev = gage_sp.slice().sort((a,b) => this.d3.ascending(a.elev, b.elev)).map(d => d.site_no)
 
         //sort ages by snow persistence
-        this.site_sp = gage_sp.slice().sort((a,b) => this.d3.ascending(a.sp, b.sp)).map(function(d) { return d.site_no })
+        this.site_sp = gage_sp.slice().sort((a,b) => this.d3.ascending(a.sp, b.sp)).map(d => d.site_no)
 
         // nest data to iterate over in plot
         // sort of inverse of series - array of objects where objs = site containing key  for site_no, mmd and day vars
          data.mmd11 = [];
           for (let i = 1; i < n; i++) {
               var key = this.site_elev[i];
-              var mmd = data_2011.map(function(d){  return d[key]; });
-              var swe = swe_2011.map(function(d){  return d[key]; });
-              var day = data_2011.map(function(d){  return d['site_water_day']; });
+              var mmd = data_2011.map(d => d[key]);
+              var swe = swe_2011.map(d => d[key]);
+              var day = data_2011.map(d => d['site_water_day']);
               data.mmd11.push({key: key, mmd: mmd, day:day, swe:swe})
           };
 
           data.mmd12 = [];
           for (let i = 1; i < n; i++) {
               var key = this.site_elev[i];
-              var mmd = data_2012.map(function(d){  return d[key]; });
-              var swe = swe_2012.map(function(d){  return d[key]; });
-              var day = data_2012.map(function(d){  return d['site_water_day']; });
+              var mmd = data_2012.map(d => d[key]);
+              var swe = swe_2012.map(d => d[key]);
+              var day = data_2012.map(d => d['site_water_day']);
               data.mmd12.push({key: key, mmd: mmd, day:day, swe:swe})
           };
 
         // array of j days for good luck
-        data.days = data_2011.length > data_2012.length ? data_2011.map(function(d) { return  d['site_water_day']}) : data_2012.map(function(d) { return  d['site_water_day']})
+        data.days = data_2011.length > data_2012.length ? data_2011.map(d => d['site_water_day']) : data_2012.map(d => d['site_water_day'])
 
         // set up g that holds ridgelines
         this.svgboth = this.d3.select('svg#mmd-line-both');
@@ -407,16 +407,12 @@ export default {
           .attr("fill-opacity",.1)
           .attr("d", d => this.line_mmd(d.mmd))
           .attr("stroke-width", "1px")
-          .attr("class", function(d) { return d.key })
+          .attr("class", d => d.key)
           .classed("ridge", true)
           .classed("mmd", true)
           .attr('pointer-events', 'visibleStroke')
-          .on("mouseover", function(data_nest) {
-            self.hover(data_nest);
-          })
-          .on("mouseout", function(data_nest){
-            self.hoverOut(data_nest);
-          });
+          .on("mouseover", d => self.hover(d))
+          .on("mouseout", d => self.hoverOut(d));
 
          // draw SWE curves
         this.group.append("path")
@@ -426,16 +422,12 @@ export default {
           .attr("fill-opacity", .1)
           .attr("d", d => this.line_swe(d.swe))
           .attr("stroke-width", "1px")
-          .attr("class", function(d) { return d.key })
+          .attr("class", d => d.key)
           .classed("ridge", true)
           .classed("swe", true)
           .attr('pointer-events', 'visibleStroke')
-          .on("mouseover", function(data_nest) {
-            self.hover(data_nest);
-          })
-          .on("mouseout", function(data_nest){
-            self.hoverOut(data_nest);
-          })
+          .on("mouseover", d => self.hover(d))
+          .on("mouseout", d => self.hoverOut(d));
 
 
         this.y2011 = this.svgboth.selectAll("g.ridge_2011") // ridge group


### PR DESCRIPTION
In this MR I worked through the console messages to address the bugs with the drawing of the ridgeline chart as well as the peak SWE and melt date maps in some browsers. For Cee, the ridgeline chart wasn't drawing, and they were seeing these console errors:

<img width="1503" alt="MicrosoftTeams-image (5)" src="https://github.com/DOI-USGS/snow-to-flow/assets/54007288/c4e5cbb1-c636-4c70-9cf5-8a73e81dc05b">

I _could_ see the ridgeline chart, and couldn't reproduce all of those errors locally, but I _think_ I've addressed them - will need testing by Cee to confirm.

And then in Microsoft Edge and Chome, in taller windows, the display of the SNOTEL map was messed up, with the Peak SWE and melt charts shrunk to a tiny size, and the US map shifted left:

![image](https://github.com/DOI-USGS/snow-to-flow/assets/54007288/3905c992-8a16-4d55-a137-9e56f8e72b98)

From the mobile preview in Edge, looks like the mobile grid was also messed up, w/ part of the legend and the WY21 chart out of view:

![image](https://github.com/DOI-USGS/snow-to-flow/assets/54007288/ebe637bd-2444-4a87-8e2d-17e11180ee59)


### Changes
* `'SWEanim.vue'`
  * Set svg height for `#mmd-line-both` svg to `100%` instead of `auto`
  * Define `i` with `let` when building for loops
  * Use longer array of `site_water_day` values from `data_2012` to set `data.day` to drop `NaN` error when drawing SWE and Streamflow areas + lines
  * Change class for SWE annotations on line so that are removed when SWE is toggled off
  * Use arrow notation throughout
  * Update deprecated event notation in `changePos()`
  * Drop 5-second transition on mouseover actions - was making the interaction feel unresponsive
  * Drop z-index adjustments of mouseovered elements in favor of raising and lowering groups that contain paths
* `'SNTLmap.vue'`
  * For `#map-grid`, set fixed equal-width for grid columns `16.6%` instead of using `fr` notation -- I think what was happening was that since `#grid-left`, `#ak`, `#grid-right`, and `#usa` all have set widths , the `repeat(6, 1fr)` notation was equally dividing the remaining free space _after_ those fixed width elements were drawn, which was forcing the column not occupied by either map (when `@media screen and (min-height: 900px)`) to be very small, thus shrinking the grid space for the `peak` and `melt` charts.
 
### To test
Pull changes locally, build site with `npm run serve` - check if this has resolved a) the console errors, b) the drawing issue with the ridgeline chart and c) the drawing issue with the SNOTEL map

### Screenshots

In tall desktop windows:
![image](https://github.com/DOI-USGS/snow-to-flow/assets/54007288/6e53bd8d-8f73-4533-99d9-1d94638070f8)

On mobile preview:
![image](https://github.com/DOI-USGS/snow-to-flow/assets/54007288/41b2b2d8-d94d-4c25-bee5-ee33eb1731fe)

### Testing:
----------------------------
Before making this pull request, I:


- [X] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [X] Chrome
- [ ] Safari
- [X] Edge
- [X] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
